### PR TITLE
Fix heap-buffer-overflow in searchTST guide buffer (CRISPRme #105)

### DIFF
--- a/sourceCode/CRISPR-Cas-Tree/main.cpp
+++ b/sourceCode/CRISPR-Cas-Tree/main.cpp
@@ -31,7 +31,6 @@ typedef struct tleaf
 {
 	int guideIndex;
 	string guideDNA;
-	const char * guideDNA_char;
 	string pamDNA;
 	int next;
 } Tleaf;
@@ -536,7 +535,7 @@ int main(int argc, char **argv)
 					tmp_pam_str = target.substr(0,pamRNA.length());
 					reverse(tmp_pam_str.begin(), tmp_pam_str.end());
 					
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length(), pamlen - pamRNA.length()+ max_bulges), target.substr(pamRNA.length(), pamlen - pamRNA.length()+ max_bulges).c_str(),
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length(), pamlen - pamRNA.length()+ max_bulges),
 					 				tmp_pam_str,
 									0}; //salvo l'indice del target
 				
@@ -612,8 +611,8 @@ int main(int argc, char **argv)
 					tmp_pam_str = tmp.substr(0,pamRNA.length());
 					reverse(tmp_pam_str.begin(), tmp_pam_str.end());
 
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length(), pamlen - pamRNA.length()+ max_bulges), tmp.substr(pamRNA.length(), pamlen - pamRNA.length()+ max_bulges).c_str(),
-					 				tmp_pam_str, 
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length(), pamlen - pamRNA.length()+ max_bulges),
+					 				tmp_pam_str,
 									 0}; //salvo l'indice del target
 				}
 			}
@@ -639,8 +638,8 @@ int main(int argc, char **argv)
 					
 					reverse(target.begin(), target.end()); //reverse per aggiungere nell'albero
 					
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length()), target.substr(pamRNA.length()).c_str(),
-									target.substr(0, pamRNA.length()), 0}; //salvo l'indice del target			
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length()),
+									target.substr(0, pamRNA.length()), 0}; //salvo l'indice del target
 					
 				}
 			}
@@ -708,7 +707,7 @@ int main(int argc, char **argv)
 							break;
 						}
 
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length()), tmp.substr(pamRNA.length()).c_str(),
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length()),
 									tmp.substr(0, pamRNA.length()),0};
 					
 				}

--- a/sourceCode/CRISPR-Cas-Tree/mainParallel.cpp
+++ b/sourceCode/CRISPR-Cas-Tree/mainParallel.cpp
@@ -37,7 +37,6 @@ typedef struct tleaf
 	int guideIndex;
 	//INSERIRE BITSET CON bitset<#sample> CHE CONTIENE INFO SAMPLES
 	string guideDNA;
-	const char *guideDNA_char;
 	string pamDNA;
 	int next;
 } Tleaf;
@@ -538,7 +537,7 @@ int main(int argc, char **argv)
 					tmp_pam_str = target.substr(0, pamRNA.length());
 					reverse(tmp_pam_str.begin(), tmp_pam_str.end());
 
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length(), pamlen - pamRNA.length() + max_bulges), target.substr(pamRNA.length(), pamlen - pamRNA.length() + max_bulges).c_str(),
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length(), pamlen - pamRNA.length() + max_bulges),
 														 tmp_pam_str,
 														 0}; //salvo l'indice del target
 				}
@@ -614,7 +613,7 @@ int main(int argc, char **argv)
 					tmp_pam_str = tmp.substr(0, pamRNA.length());
 					reverse(tmp_pam_str.begin(), tmp_pam_str.end());
 
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length(), pamlen - pamRNA.length() + max_bulges), tmp.substr(pamRNA.length(), pamlen - pamRNA.length() + max_bulges).c_str(),
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length(), pamlen - pamRNA.length() + max_bulges),
 														 tmp_pam_str,
 														 0}; //salvo l'indice del target
 				}
@@ -643,7 +642,7 @@ int main(int argc, char **argv)
 
 					reverse(target.begin(), target.end()); //reverse per aggiungere nell'albero
 
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length()), target.substr(pamRNA.length()).c_str(),
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], target.substr(pamRNA.length()),
 														 target.substr(0, pamRNA.length()), 0}; //salvo l'indice del target
 																								// cout << "pam saved positive " << targetOnDNA[counter_index].pamDNA << endl;
 				}
@@ -713,7 +712,7 @@ int main(int argc, char **argv)
 							break;
 						}
 
-					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length()), tmp.substr(pamRNA.length()).c_str(),
+					targetOnDNA[counter_index] = (Tleaf){pamIndices[i], tmp.substr(pamRNA.length()),
 														 tmp.substr(0, pamRNA.length()), 0};
 					// cout << "pam saved negative " << targetOnDNA[counter_index].pamDNA << endl;
 				}

--- a/sourceCode/CRISPR-Cas-Tree/searchOnTST.cpp
+++ b/sourceCode/CRISPR-Cas-Tree/searchOnTST.cpp
@@ -1066,11 +1066,11 @@ int main(int argc, char **argv)
 			reverse(iguide.begin(), iguide.end());
 		}
 
-		char *temp_char_guide = (char *)malloc((pamlen - pamlimit) * sizeof(char));
+		char *temp_char_guide = (char *)malloc((pamlen - pamlimit + 1) * sizeof(char));
 		// guideRNA.push_back((char *)malloc((pamlen - pamlimit) * sizeof(char)));
 		guideRNA.push_back(temp_char_guide);
 		copy(iguide.begin(), iguide.end(), guideRNA[numGuide]); // save Guide
-		guideRNA[numGuide][(pamlen - pamlimit) + 1] = '\0';
+		guideRNA[numGuide][pamlen - pamlimit] = '\0';
 		numGuide++;
 		// free(temp_char_guide);
 	}


### PR DESCRIPTION
## Summary

Fixes the CRISPRitz heap corruption behind **CRISPRme #105** (`free(): invalid pointer` abort during `search` with bulges).

## Root cause

**Primary (heap-buffer-overflow):** In `sourceCode/CRISPR-Cas-Tree/searchOnTST.cpp` the per-guide buffer is `malloc`'d with `(pamlen - pamlimit)` bytes (= `len_guide`), but the `'\0'` terminator is written at index `(pamlen - pamlimit) + 1` — **two bytes past the end of the allocation, on every guide loaded**. The copied guide occupies indices `0 .. len_guide-1`, so the terminator belongs at index `len_guide`, and the buffer needs `len_guide + 1` bytes.

This off-by-two write corrupts heap metadata. With a partially degenerate **odd-length PAM (e.g. `WTN`)** combined with a **DNA bulge (`-bDNA 1`)**, the corruption lands on the live per-leaf `guideDNA` / `guideDNA_bit` chunks that are `delete[]`-ed at the end of each search block — producing the `free(): invalid pointer` abort reported in #105.

**Secondary (dangling pointer, same family):** The `Tleaf` aggregate initializer in `main.cpp` and `mainParallel.cpp` stored the `.c_str()` of a **temporary** `std::string` into the `guideDNA_char` member — a pointer that dangles the instant the full expression ends. The member is never read (it is not serialized into the `.bin` index; the search reads the `std::string guideDNA` member), so it is removed entirely along with the four dangling initializers. The **on-disk index format is unchanged**.

> Note: the conda recipe (top-level `Makefile_conda`) builds `buildTST` from `mainParallel.cpp`, so the dangling-pointer cleanup is applied there too (identical bug also present in `main.cpp`).

## Diff

```diff
--- a/sourceCode/CRISPR-Cas-Tree/searchOnTST.cpp
+++ b/sourceCode/CRISPR-Cas-Tree/searchOnTST.cpp
-		char *temp_char_guide = (char *)malloc((pamlen - pamlimit) * sizeof(char));
+		char *temp_char_guide = (char *)malloc((pamlen - pamlimit + 1) * sizeof(char));
 		guideRNA.push_back(temp_char_guide);
 		copy(iguide.begin(), iguide.end(), guideRNA[numGuide]); // save Guide
-		guideRNA[numGuide][(pamlen - pamlimit) + 1] = '\0';
+		guideRNA[numGuide][pamlen - pamlimit] = '\0';
```

Plus removal of the unused `guideDNA_char` member and its four dangling `.c_str()` initializers in `main.cpp` and `mainParallel.cpp`.

## Validation (gcc:12 Linux container + AddressSanitizer)

Repro: tiny single-chr FASTA (8 kb), degenerate PAM file `NNNNNNNNNNNNNNNNNNNNWTN 3`, `-bDNA 1`, `OMP_NUM_THREADS=1`.

**Before fix (original, ASan):**
```
==65==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x... 
    #0 ... in main .../searchOnTST.cpp:1073
    #1 ... in main .../searchOnTST.cpp:1069   (the malloc)
SUMMARY: AddressSanitizer: heap-buffer-overflow .../searchOnTST.cpp:1073 in main
exit=1
```

**After fix (ASan):** no ASan error, search completes cleanly.
```
(no "ERROR: AddressSanitizer" / "heap-buffer-overflow" / "invalid pointer" lines)
USED THREADS 1
-----------------------
exit=0
```

**Regression — correctness unchanged (normal `NNNNNNNNNNNNNNNNNNNNNGG 3` PAM, non-ASan build):**
- `buildTST` index `.bin`: **byte-identical** (orig vs fixed).
- Search `*.targets.txt` (33 target lines incl. DNA-bulge hits): **BYTE-IDENTICAL** — `cmp` clean, `diff` empty.

## Release note

Targets a **2.7.1** patch. CRISPRme currently pins CRISPRitz and will repin after the patch release.

cc @ManuelTgn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
