### PR TITLE
Release 2.7.1: version bump (#105 fix)

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "2.7.1" %}
 
 package:
   name: crispritz

--- a/crispritz.py
+++ b/crispritz.py
@@ -18,7 +18,7 @@ origin_path = os.path.dirname(os.path.realpath(__file__))
 # conda path
 conda_path = "opt/crispritz/"
 
-VERSION = "2.6.6"
+VERSION = "2.7.1"
 
 if "--debug" in sys.argv[1:]:
     # for quick local tests


### PR DESCRIPTION
Bump to 2.7.1 for the CRISPRme #105 heap-overflow fix (#19) + the new CI (#20). 🤖 Generated with [Claude Code](https://claude.com/claude-code)