### PR TITLE
add-variants: memory-bounded cross-chromosome parallelism + use compiled enricher

### DIFF
--- a/Makefile_conda
+++ b/Makefile_conda
@@ -3,3 +3,4 @@ crispritz:
 	$(CXX) -std=c++11 -O3 -fopenmp -I $(BUILD_PREFIX)/include sourceCode/CRISPR-Cas-Tree/mainParallel.cpp -o buildTST
 	$(CXX) -std=c++11 -O3 -fopenmp -I $(BUILD_PREFIX)/include sourceCode/CRISPR-Cas-Tree/searchOnTST.cpp sourceCode/CRISPR-Cas-Tree/detailedOutput.cpp sourceCode/CRISPR-Cas-Tree/convert.cpp -I sourceCode/CRISPR-Cas-Tree/include -o searchTST
 	$(CXX) -std=c++11 -O3 -fopenmp -I $(BUILD_PREFIX)/include sourceCode/CRISPRofiler/main.cpp sourceCode/CRISPRofiler/profiling.cpp sourceCode/CRISPRofiler/guide_searching.cpp sourceCode/CRISPRofiler/pam_searching.cpp sourceCode/CRISPRofiler/pre_computation.cpp sourceCode/CRISPRofiler/reading.cpp sourceCode/CRISPRofiler/analysis.cpp -o searchBruteForce
+	$(CXX) -std=c++11 -O3 -fopenmp -I $(BUILD_PREFIX)/include sourceCode/Python_Scripts/Enrichment/enricher.cpp -o enricher -lz

--- a/crispritz.py
+++ b/crispritz.py
@@ -560,10 +560,26 @@ def annotateResults():
         print("Annotation runtime: %s seconds" % (time.time() - start_time))
 
 
+def _enricher_command():
+    """Resolve the enrichment executable, preferring the compiled binary.
+
+    Order: a binary named ``enricher`` on PATH, then the compiled binary shipped
+    alongside the reference implementation, else the Python reference script.
+    Returns a list suitable to prepend to the 5 positional enricher args.
+    """
+    found = shutil.which("enricher")
+    if found:
+        return [found]
+    compiled = corrected_origin_path + "Python_Scripts/Enrichment/enricher"
+    if os.path.isfile(compiled) and os.access(compiled, os.X_OK):
+        return [compiled]
+    return [corrected_origin_path + "Python_Scripts/Enrichment/enricher.py"]
+
+
 def genomeEnrichment_subprocess_VCF(altfile, genfile, dirGenome, doit, dirVCFFiles):
     subprocess.run(
-        [
-            corrected_origin_path + "Python_Scripts/Enrichment/enricher.py",
+        _enricher_command()
+        + [
             altfile,
             genfile,
             dirGenome.split("/")[-1],
@@ -571,6 +587,29 @@ def genomeEnrichment_subprocess_VCF(altfile, genfile, dirGenome, doit, dirVCFFil
             dirVCFFiles,
         ]
     )
+
+
+def _enrichment_workers(th_from_flag, th_provided, n_chroms):
+    """Choose the number of enrichment workers under a memory budget.
+
+    Each worker loads ~one chromosome, so unbounded fan-out can exhaust RAM.
+    Mirrors the CRISPRme post-analysis cap (CRISPRME_MAX_MEM_GB, default 64).
+    """
+    import os
+
+    try:
+        budget = float(os.environ.get("CRISPRME_MAX_MEM_GB", "64"))
+    except ValueError:
+        budget = 64.0
+    try:
+        per = float(os.environ.get("CRISPRME_ENRICH_WORKER_GB", "3"))
+    except ValueError:
+        per = 3.0
+    if per <= 0:
+        per = 3.0
+    mem_cap = max(1, int(budget // per))
+    base = th_from_flag if th_provided else (os.cpu_count() or 1)
+    return max(1, min(base, mem_cap, n_chroms))
 
 
 def genomeEnrichment():
@@ -635,6 +674,7 @@ def genomeEnrichment():
 
     # read number of mismatches
     th = 1
+    th_provided = "-th" in sys.argv[1:]
     if "-th" in sys.argv[1:]:
         try:
             th = (sys.argv).index("-th") + 1
@@ -668,7 +708,28 @@ def genomeEnrichment():
 
     os.chdir("../")
     # os.chdir(dirParsedFiles)
-    pool = multiprocessing.Pool(th)
+    n_workers = _enrichment_workers(th, th_provided, len(listChrs))
+    print(
+        "add-variants: enriching %d chromosome(s) with %d worker(s) "
+        "(mem budget %s GB, ~%s GB/worker)"
+        % (
+            len(listChrs),
+            n_workers,
+            os.environ.get("CRISPRME_MAX_MEM_GB", "64"),
+            os.environ.get("CRISPRME_ENRICH_WORKER_GB", "3"),
+        ),
+        file=sys.stderr,
+    )
+    # Use a 'fork' context: crispritz.py runs its command dispatch at module
+    # scope (no __main__ guard), so a 'spawn' start method would re-import and
+    # re-invoke add-variants inside every worker. 'fork' is the Linux default
+    # (the CRISPRme production platform); we request it explicitly so parallel
+    # enrichment behaves identically on macOS.
+    try:
+        mp_ctx = multiprocessing.get_context("fork")
+    except ValueError:
+        mp_ctx = multiprocessing
+    pool = mp_ctx.Pool(n_workers)
 
     print("Variants Extraction and Processing START")
     start_time = time.time()

--- a/sourceCode/Python_Scripts/Enrichment/add_variants.sh
+++ b/sourceCode/Python_Scripts/Enrichment/add_variants.sh
@@ -2,5 +2,23 @@
 # $1 is vcf file (Eg. variants_hg38/ALL.chr1.vcf.gz)
 # $2 is chrname with file extension(Eg. chr1.fa)
 # $3 is chrname (Eg. chr1)
+#
+# Invokes the compiled C++ `enricher` (a byte-identical port of enricher.py,
+# the reference implementation kept alongside this script). The C++ binary is
+# built by `make -f Makefile_conda crispritz` and installed on PATH; fall back
+# to the copy sitting next to this script if it is not on PATH.
 
-bcftools consensus -I -M N -f $2 $1 > $3'.enriched.fa'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if command -v enricher >/dev/null 2>&1; then
+    ENRICHER="enricher"
+elif [ -x "$SCRIPT_DIR/enricher" ]; then
+    ENRICHER="$SCRIPT_DIR/enricher"
+else
+    echo "ERROR: 'enricher' binary not found (build it via Makefile_conda)." >&2
+    exit 1
+fi
+
+# enricher <vcf.gz> <chrom.fa> <argv3-prefix> <yes|no> <argv5-path-for-fakedir-name>
+# Argument order matches enricher.py exactly.
+"$ENRICHER" "$1" "$2" "$3" "yes" "$1"

--- a/sourceCode/Python_Scripts/Enrichment/enricher.cpp
+++ b/sourceCode/Python_Scripts/Enrichment/enricher.cpp
@@ -1,0 +1,689 @@
+// C++ port of enricher.py (CRISPRitz variant-enrichment / "add-variants" step).
+//
+// Behaviorally byte-identical to sourceCode/Python_Scripts/Enrichment/enricher.py.
+// Reproduces the same four outputs (enriched FASTA, my_dict_<chr>.json,
+// fake<chr>.fa, log<chr>.txt) including the original script's cwd side effects.
+//
+// Build: $(CXX) -std=c++11 -O3 -fopenmp ... enricher.cpp -o enricher -lz
+//
+// Usage: enricher <vcf.gz> <chrom.fa> <argv3prefix> <yes|no> <argv5path>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <map>
+#include <set>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+#include <zlib.h>
+
+// ---------------------------------------------------------------------------
+// small helpers
+// ---------------------------------------------------------------------------
+
+static std::vector<std::string> splitStr(const std::string &s, char delim) {
+    std::vector<std::string> out;
+    size_t start = 0;
+    while (true) {
+        size_t pos = s.find(delim, start);
+        if (pos == std::string::npos) {
+            out.push_back(s.substr(start));
+            break;
+        }
+        out.push_back(s.substr(start, pos - start));
+        start = pos + 1;
+    }
+    return out;
+}
+
+// Python str.strip(): removes leading/trailing ASCII whitespace.
+static std::string pyStrip(const std::string &s) {
+    size_t b = 0, e = s.size();
+    while (b < e && (s[b] == ' ' || s[b] == '\t' || s[b] == '\n' ||
+                     s[b] == '\r' || s[b] == '\f' || s[b] == '\v'))
+        ++b;
+    while (e > b && (s[e - 1] == ' ' || s[e - 1] == '\t' || s[e - 1] == '\n' ||
+                     s[e - 1] == '\r' || s[e - 1] == '\f' || s[e - 1] == '\v'))
+        --e;
+    return s.substr(b, e - b);
+}
+
+// ---------------------------------------------------------------------------
+// gzip line reader
+// ---------------------------------------------------------------------------
+
+struct GzReader {
+    gzFile fp;
+    std::string buf;
+    size_t pos;
+    bool eof;
+    GzReader(const char *path) : pos(0), eof(false) {
+        fp = gzopen(path, "rb");
+        if (!fp) {
+            fprintf(stderr, "ERROR: cannot open %s\n", path);
+            exit(1);
+        }
+    }
+    ~GzReader() {
+        if (fp) gzclose(fp);
+    }
+    // Returns false at EOF with no more data. Line includes no trailing '\n'
+    // (we strip it here since callers always strip/split anyway, except the
+    // VCF header read which in python keeps the split-on-tab of a raw line).
+    bool getRawLine(std::string &line) {
+        line.clear();
+        while (true) {
+            if (pos >= buf.size()) {
+                if (eof) return !line.empty();
+                char tmp[1 << 16];
+                int n = gzread(fp, tmp, sizeof(tmp));
+                if (n <= 0) {
+                    eof = true;
+                    if (line.empty()) return false;
+                    return true;
+                }
+                buf.assign(tmp, tmp + n);
+                pos = 0;
+            }
+            while (pos < buf.size()) {
+                char c = buf[pos++];
+                if (c == '\n') return true;
+                line.push_back(c);
+            }
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// IUPAC mapping: base SET -> ambiguity letter (order-independent).
+// Canonicalize the set of {A,C,G,T} present into a 4-bit mask.
+// ---------------------------------------------------------------------------
+
+static inline int baseBit(char c) {
+    switch (c) {
+        case 'A': return 1;
+        case 'C': return 2;
+        case 'G': return 4;
+        case 'T': return 8;
+        default:  return 0;  // non-ACGT contributes nothing recognizable
+    }
+}
+
+// Maps a mask of ACGT bits to the IUPAC letter reproduced by enricher.py.
+static char iupacFromMask(int mask) {
+    switch (mask) {
+        case 1:  return 'A';
+        case 2:  return 'C';
+        case 4:  return 'G';
+        case 8:  return 'T';
+        case (1 | 4):     return 'R';  // A,G
+        case (2 | 8):     return 'Y';  // C,T
+        case (4 | 2):     return 'S';  // G,C
+        case (1 | 8):     return 'W';  // A,T
+        case (4 | 8):     return 'K';  // G,T
+        case (1 | 2):     return 'M';  // A,C
+        case (2 | 4 | 8): return 'B';  // C,G,T
+        case (1 | 4 | 8): return 'D';  // A,G,T
+        case (1 | 2 | 8): return 'H';  // A,C,T
+        case (1 | 2 | 4): return 'V';  // A,C,G
+        case (1 | 2 | 4 | 8): return 'N';  // A,C,G,T
+        default: return 0;  // no matching key -> genome unchanged (python: no key hit)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// case-insensitive replacement of the FIRST occurrence of `pat` in `s`,
+// reproducing re.sub(pat, repl, s, count=1, flags=IGNORECASE).
+// The VCF ref/alt strings here are plain literals (no regex metachars in
+// nucleotide sequences), so a literal case-insensitive find is equivalent.
+// ---------------------------------------------------------------------------
+
+static std::string reSubFirstCI(const std::string &pat, const std::string &repl,
+                                const std::string &s) {
+    if (pat.empty()) {
+        // re.sub with empty pattern inserts at position 0; not expected for
+        // nucleotide refs (always length >= 1). Guard anyway.
+        return repl + s;
+    }
+    size_t n = s.size(), m = pat.size();
+    for (size_t i = 0; i + m <= n; ++i) {
+        bool match = true;
+        for (size_t j = 0; j < m; ++j) {
+            char a = s[i + j], b = pat[j];
+            if (a >= 'a' && a <= 'z') a -= 32;
+            if (b >= 'a' && b <= 'z') b -= 32;
+            if (a != b) { match = false; break; }
+        }
+        if (match) {
+            return s.substr(0, i) + repl + s.substr(i + m);
+        }
+    }
+    return s;  // no match -> unchanged, matching re.sub behavior
+}
+
+// ---------------------------------------------------------------------------
+// globals mirroring the python module-level state
+// ---------------------------------------------------------------------------
+
+static std::string genomeStr;
+static std::string genomeHeader;    // includes leading '>' and trailing '\n'
+static std::string currentChr;
+static std::vector<std::string> VCFheader;
+
+// enriched genome is edited in place on a copy of genomeStr
+static std::string genomeList;
+
+// SNP dict: preserve insertion order (python dict) -> use vector of pairs,
+// with a lookup map for "already present" overwrite semantics.
+static std::vector<std::pair<std::string, std::string>> chr_dict_snps;
+static std::map<std::string, size_t> chr_dict_index;
+
+static void dictSet(const std::string &key, const std::string &val) {
+    std::map<std::string, size_t>::iterator it = chr_dict_index.find(key);
+    if (it != chr_dict_index.end()) {
+        chr_dict_snps[it->second].second = val;  // overwrite, keep position
+    } else {
+        chr_dict_index[key] = chr_dict_snps.size();
+        chr_dict_snps.push_back(std::make_pair(key, val));
+    }
+}
+
+// fake indel fasta pieces and log rows
+static std::vector<std::string> list_fasta_indels;
+static std::vector<std::vector<std::string>> log_indels;  // 7 cols each
+
+static bool doYes = false;
+
+// ---------------------------------------------------------------------------
+// SNPsProcess(line): mutates genomeList and line[1] -> 0-based.
+// ---------------------------------------------------------------------------
+
+static void SNPsProcess(std::vector<std::string> &line) {
+    if (line[3].size() > 1) return;  // not a SNP
+    long pos0 = strtol(line[1].c_str(), NULL, 10) - 1;
+    line[1] = std::to_string(pos0);  // python sets line[1] to 1-based-1
+
+    // build the base SET: reference base + each alt allele of length 1
+    int mask = baseBit(genomeStr[pos0]);
+    std::vector<std::string> altAlleles = splitStr(pyStrip(line[4]), ',');
+    for (size_t k = 0; k < altAlleles.size(); ++k) {
+        if (altAlleles[k].size() > 1) continue;
+        if (!altAlleles[k].empty()) mask |= baseBit(altAlleles[k][0]);
+    }
+    char letter = iupacFromMask(mask);
+    if (letter != 0) {
+        genomeList[pos0] = letter;
+    }
+    // if letter==0, python loop found no matching value -> genome unchanged.
+}
+
+// ---------------------------------------------------------------------------
+// add_to_dict_snps(line, pos_AF)
+// ---------------------------------------------------------------------------
+
+static void add_to_dict_snps(const std::vector<std::string> &line, int pos_AF) {
+    if (line[3].size() == 1 && line[4].size() == 1) {
+        // Case A: biallelic SNP
+        std::vector<std::string> list_samples;
+        for (size_t p = 9; p < line.size(); ++p) {
+            const std::string &i = line[p];
+            std::string gt = splitStr(i, ':')[0];
+            if (gt.find('1') != std::string::npos) {
+                list_samples.push_back(VCFheader[p] + ":" + gt);
+            }
+        }
+        std::string chr_pos_string = currentChr + "," + line[1];
+        std::string rsID = line[2];
+        std::string af = splitStr(line[7], ';')[pos_AF].substr(3);
+        std::string val;
+        if (!list_samples.empty()) {
+            std::vector<std::string> sorted_s = list_samples;
+            std::sort(sorted_s.begin(), sorted_s.end());
+            std::string joined;
+            for (size_t k = 0; k < sorted_s.size(); ++k) {
+                if (k) joined += ",";
+                joined += sorted_s[k];
+            }
+            val = joined + ";" + line[3] + "," + line[4] + ";" + rsID + ";" + af;
+        } else {
+            val = std::string(";") + line[3] + "," + line[4] + ";" + rsID + ";" + af;
+        }
+        dictSet(chr_pos_string, val);
+    } else if (line[3].size() == 1) {
+        // Case B: multiallelic, ref length 1
+        std::vector<std::string> variants = splitStr(line[4], ',');
+        std::vector<std::string> snps;
+        std::vector<int> values_for_allele_info;
+        for (size_t v = 0; v < variants.size(); ++v) {
+            if (variants[v].size() == 1) {
+                snps.push_back(variants[v]);
+                values_for_allele_info.push_back((int)v + 1);
+            }
+        }
+        // dict_of_lists_samples keyed by snp string; python uses a dict so
+        // duplicate snp strings collapse. Preserve that: map snp->list.
+        std::map<std::string, std::vector<std::string>> dols;
+        for (size_t k = 0; k < snps.size(); ++k) dols[snps[k]];  // default-init
+        if (!snps.empty()) {
+            for (size_t p = 9; p < line.size(); ++p) {
+                const std::string &sample = line[p];
+                std::string gt = splitStr(sample, ':')[0];
+                for (size_t idx = 0; idx < values_for_allele_info.size(); ++idx) {
+                    std::string vstr = std::to_string(values_for_allele_info[idx]);
+                    if (gt.find(vstr) != std::string::npos) {
+                        dols[snps[idx]].push_back(VCFheader[p] + ":" + gt);
+                        break;
+                    }
+                }
+            }
+            std::string chr_pos_string = currentChr + "," + line[1];
+            std::string rsID0 = splitStr(line[2], ',')[0];
+            std::vector<std::string> af = splitStr(splitStr(line[7], ';')[pos_AF].substr(3), ',');
+
+            std::vector<std::string> final_entry;
+            for (size_t idx = 0; idx < snps.size(); ++idx) {
+                std::vector<std::string> &samps = dols[snps[idx]];
+                std::string entry;
+                if (!samps.empty()) {
+                    std::vector<std::string> sorted_s = samps;
+                    std::sort(sorted_s.begin(), sorted_s.end());
+                    std::string joined;
+                    for (size_t k = 0; k < sorted_s.size(); ++k) {
+                        if (k) joined += ",";
+                        joined += sorted_s[k];
+                    }
+                    entry = joined + ";" + line[3] + "," + snps[idx] + ";" + rsID0 +
+                            ";" + af[values_for_allele_info[idx] - 1];
+                } else {
+                    entry = std::string(";") + line[3] + "," + snps[idx] + ";" + rsID0 +
+                            ";" + af[values_for_allele_info[idx] - 1];
+                }
+                final_entry.push_back(entry);
+            }
+            std::string joined;
+            for (size_t k = 0; k < final_entry.size(); ++k) {
+                if (k) joined += "$";
+                joined += final_entry[k];
+            }
+            dictSet(chr_pos_string, joined);
+        }
+    }
+    // len(line[3])>1 : stores nothing
+}
+
+// ---------------------------------------------------------------------------
+// indel_to_fasta(line, id_indel, pos_AF, start_fake_pos)
+// returns updated (id_indel, start_fake_pos)
+// ---------------------------------------------------------------------------
+
+static void indel_to_fasta(const std::vector<std::string> &line, long &id_indel,
+                           int pos_AF, long &start_fake_pos) {
+    bool cond = (line[3].size() > 1 || line[4].size() > 1) &&
+                line[3].find('<') == std::string::npos;
+    if (!cond) return;
+
+    std::vector<std::string> indels;
+    std::vector<int> values_for_allele_info;
+    if (line[4].find(',') != std::string::npos) {
+        std::vector<std::string> splitted = splitStr(line[4], ',');
+        for (size_t v = 0; v < splitted.size(); ++v) {
+            const std::string &s = splitted[v];
+            bool isIndel = (s.size() != line[3].size() ||
+                            (s.size() > 1 && line[3].size() > 1)) &&
+                           s.find('<') == std::string::npos;
+            if (isIndel) {
+                indels.push_back(s);
+                values_for_allele_info.push_back((int)v + 1);
+            }
+        }
+    } else if (((line[4].size() != line[3].size()) ||
+                (line[4].size() > 1 && line[3].size() > 1)) &&
+               line[4].find('<') == std::string::npos) {
+        indels.push_back(line[4]);
+        values_for_allele_info.push_back(1);
+    }
+
+    if (indels.empty()) return;
+
+    std::map<std::string, std::vector<std::string>> dols;
+    for (size_t k = 0; k < indels.size(); ++k) dols[indels[k]];
+    for (size_t p = 9; p < line.size(); ++p) {
+        std::string gt = splitStr(line[p], ':')[0];
+        for (size_t idx = 0; idx < values_for_allele_info.size(); ++idx) {
+            std::string vstr = std::to_string(values_for_allele_info[idx]);
+            if (gt.find(vstr) != std::string::npos) {
+                dols[indels[idx]].push_back(VCFheader[p]);
+                break;
+            }
+        }
+    }
+
+    std::string rsID0 = splitStr(line[2], ',')[0];
+    std::vector<std::string> af = splitStr(splitStr(line[7], ';')[pos_AF].substr(3), ',');
+
+    long posv = strtol(line[1].c_str(), NULL, 10);
+    long start_position = posv - 26;
+    long end_position = posv + 26 + (long)line[3].size();
+    std::string sub_fasta = genomeStr.substr(start_position, end_position - start_position);
+
+    for (size_t idx = 0; idx < indels.size(); ++idx) {
+        std::vector<std::string> &samps = dols[indels[idx]];
+        if (!samps.empty()) {
+            std::string indel_info =
+                currentChr + "_" + line[1] + "_" + line[3] + "_" + indels[idx];
+            // sub_fasta = sub_fasta[0:25] + re.sub(ref, indel, sub_fasta[25:], 1, IGNORECASE)
+            std::string head = sub_fasta.substr(0, 25);
+            std::string tail = sub_fasta.substr(25);
+            sub_fasta = head + reSubFirstCI(line[3], indels[idx], tail);
+
+            list_fasta_indels.push_back(sub_fasta + "\n" + "N\n");
+
+            std::string refseq = genomeStr.substr(start_position, sub_fasta.size());
+            long end_fake_pos = start_fake_pos + (long)sub_fasta.size();
+
+            std::string samplesJoined;
+            for (size_t k = 0; k < samps.size(); ++k) {
+                if (k) samplesJoined += ",";
+                samplesJoined += samps[k];
+            }
+            std::vector<std::string> row(7);
+            row[0] = currentChr + "_" + std::to_string(start_position) + "-" +
+                     std::to_string(end_position) + "_" + std::to_string(id_indel);
+            row[1] = samplesJoined;
+            row[2] = rsID0;
+            row[3] = af[values_for_allele_info[idx] - 1];
+            row[4] = indel_info;
+            row[5] = std::to_string(start_fake_pos) + "," + std::to_string(end_fake_pos);
+            row[6] = refseq;
+            log_indels.push_back(row);
+
+            id_indel += 1;
+            start_fake_pos = end_fake_pos + 1;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialization matching python json.dump defaults:
+//   {"k": "v", "k2": "v2"}  -- separators ", " and ": ", insertion order.
+// Our values are ASCII; still escape " and \ and control chars per json spec.
+// ---------------------------------------------------------------------------
+
+static std::string jsonEscape(const std::string &s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    for (size_t i = 0; i < s.size(); ++i) {
+        unsigned char c = (unsigned char)s[i];
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b"; break;
+            case '\f': out += "\\f"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    char buf[8];
+                    snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else {
+                    out += (char)c;
+                }
+        }
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// pandas to_csv(index=False, sep='\t') quoting.
+// pandas default quoting = QUOTE_MINIMAL: quotes a field only if it contains
+// the sep, a quotechar ("), or a line terminator (\n / \r). Commas do NOT
+// trigger quoting when sep is a tab. Verified empirically against pandas.
+// ---------------------------------------------------------------------------
+
+static std::string csvField(const std::string &s) {
+    bool needQuote = false;
+    for (size_t i = 0; i < s.size(); ++i) {
+        char c = s[i];
+        if (c == '\t' || c == '"' || c == '\n' || c == '\r') { needQuote = true; break; }
+    }
+    if (!needQuote) return s;
+    std::string out = "\"";
+    for (size_t i = 0; i < s.size(); ++i) {
+        if (s[i] == '"') out += "\"\"";
+        else out += s[i];
+    }
+    out += "\"";
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char **argv) {
+    time_t start_time = time(NULL);
+    printf("READING VCF FILE AND CHROMOSOME\n");
+
+    if (argc < 6) {
+        fprintf(stderr,
+                "Usage: %s <vcf.gz> <chrom.fa> <argv3> <yes|no> <argv5path>\n",
+                argv[0]);
+        return 1;
+    }
+
+    std::string altFile = argv[1];
+    std::string genomeFile = argv[2];
+    std::string dir_enr_name = std::string(argv[3]) + "_enriched";
+    std::string argv4 = argv[4];
+    doYes = (argv4 == "yes");
+
+    // vcfName = os.path.basename(argv[5])
+    std::string arg5 = argv[5];
+    std::string vcfName;
+    {
+        size_t slash = arg5.find_last_of('/');
+        vcfName = (slash == std::string::npos) ? arg5 : arg5.substr(slash + 1);
+    }
+
+    // --- read FASTA ---
+    FILE *gf = fopen(genomeFile.c_str(), "r");
+    if (!gf) {
+        fprintf(stderr, "ERROR: cannot open %s\n", genomeFile.c_str());
+        return 1;
+    }
+    // read header line (keep raw, including trailing '\n' like python readline)
+    {
+        std::string headerLine;
+        int c;
+        while ((c = fgetc(gf)) != EOF) {
+            headerLine.push_back((char)c);
+            if (c == '\n') break;
+        }
+        genomeHeader = headerLine;  // includes '>' and '\n' (if present)
+        // currentChr = header[1:].strip()
+        std::string h = genomeHeader.substr(genomeHeader.empty() ? 0 : 1);
+        currentChr = pyStrip(h);
+        if (currentChr.find("chr") == std::string::npos) {
+            currentChr = "chr" + currentChr;
+        }
+    }
+    // read rest, remove '\n', uppercase
+    {
+        std::string rest;
+        char buf[1 << 16];
+        size_t n;
+        while ((n = fread(buf, 1, sizeof(buf), gf)) > 0) {
+            rest.append(buf, n);
+        }
+        fclose(gf);
+        genomeStr.reserve(rest.size());
+        for (size_t i = 0; i < rest.size(); ++i) {
+            char c = rest[i];
+            if (c == '\n') continue;
+            if (c >= 'a' && c <= 'z') c -= 32;
+            genomeStr.push_back(c);
+        }
+    }
+    genomeList = genomeStr;  // mutable copy
+
+    // --- open VCF ---
+    GzReader vcf(altFile.c_str());
+    // python: VCFheader = inAltFile.readline().split('\t')  (first line, unused;
+    // it gets overwritten by the #CHROM search below). Consume first line.
+    {
+        std::string firstLine;
+        vcf.getRawLine(firstLine);  // discarded (matches python overwrite)
+    }
+
+    // set up yes-mode structures / directories BEFORE the loop (python does
+    // this in original cwd).
+    long id_indel = 1;
+    long start_fake_pos = 0;
+    std::string fakeDir;
+    if (doYes) {
+        fakeDir = "fake_" + vcfName + "_" + currentChr;
+        struct stat st;
+        if (stat(fakeDir.c_str(), &st) != 0) {
+            mkdir(fakeDir.c_str(), 0777);
+        }
+    }
+
+    // find #CHROM header line
+    printf("START ENRICHMENT WITH SNVs AND SVs\n");
+    {
+        std::string line;
+        while (vcf.getRawLine(line)) {
+            if (line.find("#CHROM") != std::string::npos) {
+                VCFheader = splitStr(pyStrip(line), '\t');
+                break;
+            }
+        }
+    }
+
+    // process data lines
+    bool first_line = true;
+    int pos_AF = 0;
+    std::string raw;
+    while (vcf.getRawLine(raw)) {
+        std::vector<std::string> line = splitStr(pyStrip(raw), '\t');
+        if (first_line) {
+            first_line = false;
+            std::vector<std::string> splitted = splitStr(line[7], ';');
+            for (size_t p = 0; p < splitted.size(); ++p) {
+                if (splitted[p].size() >= 2 && splitted[p][0] == 'A' &&
+                    splitted[p][1] == 'F') {
+                    pos_AF = (int)p;
+                    break;
+                }
+            }
+        }
+        if (line[6] != "PASS") continue;
+        if (doYes) {
+            add_to_dict_snps(line, pos_AF);
+            indel_to_fasta(line, id_indel, pos_AF, start_fake_pos);
+        }
+        SNPsProcess(line);
+    }
+
+    // --- chromosomeSave(): os.chdir("./SNPs_genome/") then write ---
+    if (chdir("./SNPs_genome") != 0) {
+        fprintf(stderr, "ERROR: cannot chdir into ./SNPs_genome\n");
+        return 1;
+    }
+    {
+        struct stat st;
+        if (stat(dir_enr_name.c_str(), &st) != 0) {
+            mkdir(dir_enr_name.c_str(), 0777);
+        }
+        // genomeHeader[1:(len-1)] : strip leading '>' and trailing '\n'
+        std::string hcore;
+        if (genomeHeader.size() >= 2) {
+            hcore = genomeHeader.substr(1, genomeHeader.size() - 2);
+        }
+        std::string outPath = dir_enr_name + "/" + hcore + ".enriched.fa";
+        FILE *out = fopen(outPath.c_str(), "w");
+        if (!out) {
+            fprintf(stderr, "ERROR: cannot write %s\n", outPath.c_str());
+            return 1;
+        }
+        fwrite(genomeHeader.data(), 1, genomeHeader.size(), out);
+        fwrite(genomeList.data(), 1, genomeList.size(), out);
+        fputc('\n', out);
+        fclose(out);
+    }
+
+    if (doYes) {
+        // dictSave(): writes my_dict_<chr>.json in current cwd (SNPs_genome)
+        {
+            std::string jpath = "my_dict_" + currentChr + ".json";
+            FILE *jf = fopen(jpath.c_str(), "w");
+            if (!jf) {
+                fprintf(stderr, "ERROR: cannot write %s\n", jpath.c_str());
+                return 1;
+            }
+            std::string js = "{";
+            for (size_t k = 0; k < chr_dict_snps.size(); ++k) {
+                if (k) js += ", ";
+                js += "\"" + jsonEscape(chr_dict_snps[k].first) + "\": \"" +
+                      jsonEscape(chr_dict_snps[k].second) + "\"";
+            }
+            js += "}";
+            fwrite(js.data(), 1, js.size(), jf);
+            fclose(jf);
+        }
+
+        // logIndelsSave():
+        //   - fasta_out opened at ORIGINAL cwd path fakeDir/fake<chr>.fa
+        //     but we are now in SNPs_genome, so use ../ + fakeDir.
+        //   - log<chr>.txt written in current cwd (SNPs_genome).
+        {
+            std::string fastaPath = "../" + fakeDir + "/fake" + currentChr + ".fa";
+            FILE *ff = fopen(fastaPath.c_str(), "w");
+            if (!ff) {
+                fprintf(stderr, "ERROR: cannot write %s\n", fastaPath.c_str());
+                return 1;
+            }
+            std::string content = ">fake" + currentChr + "\n";
+            for (size_t k = 0; k < list_fasta_indels.size(); ++k) {
+                content += list_fasta_indels[k];
+            }
+            fwrite(content.data(), 1, content.size(), ff);
+            fclose(ff);
+        }
+        {
+            std::string logPath = "log" + currentChr + ".txt";
+            FILE *lf = fopen(logPath.c_str(), "w");
+            if (!lf) {
+                fprintf(stderr, "ERROR: cannot write %s\n", logPath.c_str());
+                return 1;
+            }
+            const char *cols[7] = {"CHR", "SAMPLES", "rsID", "AF",
+                                   "indel", "FAKEPOS", "refseq"};
+            std::string out;
+            for (int c = 0; c < 7; ++c) {
+                if (c) out += "\t";
+                out += cols[c];
+            }
+            out += "\n";
+            for (size_t r = 0; r < log_indels.size(); ++r) {
+                for (int c = 0; c < 7; ++c) {
+                    if (c) out += "\t";
+                    out += csvField(log_indels[r][c]);
+                }
+                out += "\n";
+            }
+            fwrite(out.data(), 1, out.size(), lf);
+            fclose(lf);
+        }
+    }
+
+    printf("DONE IN  %d  seconds\n", (int)(time(NULL) - start_time));
+    return 0;
+}

--- a/sourceCode/Python_Scripts/Enrichment/enricher.cpp
+++ b/sourceCode/Python_Scripts/Enrichment/enricher.cpp
@@ -9,6 +9,7 @@
 // Usage: enricher <vcf.gz> <chrom.fa> <argv3prefix> <yes|no> <argv5path>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -549,9 +550,10 @@ int main(int argc, char **argv) {
     std::string fakeDir;
     if (doYes) {
         fakeDir = "fake_" + vcfName + "_" + currentChr;
-        struct stat st;
-        if (stat(fakeDir.c_str(), &st) != 0) {
-            mkdir(fakeDir.c_str(), 0777);
+        // race-safe: concurrent workers may create this dir; treat EEXIST as OK.
+        if (mkdir(fakeDir.c_str(), 0777) != 0 && errno != EEXIST) {
+            fprintf(stderr, "ERROR: cannot create %s\n", fakeDir.c_str());
+            return 1;
         }
     }
 
@@ -598,9 +600,11 @@ int main(int argc, char **argv) {
         return 1;
     }
     {
-        struct stat st;
-        if (stat(dir_enr_name.c_str(), &st) != 0) {
-            mkdir(dir_enr_name.c_str(), 0777);
+        // race-safe: this shared <dirGenome>_enriched dir is created by every
+        // concurrent worker; treat EEXIST as success.
+        if (mkdir(dir_enr_name.c_str(), 0777) != 0 && errno != EEXIST) {
+            fprintf(stderr, "ERROR: cannot create %s\n", dir_enr_name.c_str());
+            return 1;
         }
         // genomeHeader[1:(len-1)] : strip leading '>' and trailing '\n'
         std::string hcore;

--- a/sourceCode/Python_Scripts/Enrichment/verify_enricher.sh
+++ b/sourceCode/Python_Scripts/Enrichment/verify_enricher.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Verify the C++ enricher is byte-identical to the reference enricher.py.
+#
+# Builds a small synthetic chromosome FASTA + gzipped VCF containing a mix of
+# variant types (biallelic SNP, multiallelic SNP, non-PASS -> skipped,
+# insertion, deletion, multiallelic indel), then runs BOTH enricher.py and the
+# compiled `enricher` on identical inputs in separate dirs (mode "yes") and
+# diffs all four outputs.
+#
+# Prints "BYTE-IDENTICAL: PASS" only if every output diff is empty.
+#
+# Usage: verify_enricher.sh [path-to-enricher-binary]
+#        (defaults to ./enricher, then /tmp/enricher_opt)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENRICHER_PY="$SCRIPT_DIR/enricher.py"
+
+# locate C++ binary
+if [ "${1:-}" != "" ]; then
+    ENRICHER_BIN="$1"
+elif [ -x "$SCRIPT_DIR/enricher" ]; then
+    ENRICHER_BIN="$SCRIPT_DIR/enricher"
+elif [ -x "./enricher" ]; then
+    ENRICHER_BIN="$(pwd)/enricher"
+elif [ -x "/tmp/enricher_opt" ]; then
+    ENRICHER_BIN="/tmp/enricher_opt"
+else
+    echo "ERROR: cannot find enricher binary. Build it or pass its path." >&2
+    exit 1
+fi
+echo "Using C++ binary: $ENRICHER_BIN"
+echo "Using reference : $ENRICHER_PY"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+echo "Work dir: $WORK"
+
+# ---------------------------------------------------------------------------
+# synthetic chromosome FASTA (a few hundred bp, mixed case to exercise upper())
+# ---------------------------------------------------------------------------
+CHR_FA="$WORK/chrTest.fa"
+python3 - "$CHR_FA" <<'PY'
+import sys, random
+random.seed(1234)
+seq = ''.join(random.choice('ACGTacgt') for _ in range(400))
+with open(sys.argv[1], 'w') as f:
+    f.write(">chrTest\n")
+    # wrap at 60 cols like real fasta
+    for i in range(0, len(seq), 60):
+        f.write(seq[i:i+60] + "\n")
+PY
+
+# uppercased reference sequence, for building valid REF fields
+REFSEQ="$(python3 - "$CHR_FA" <<'PY'
+import sys
+lines=open(sys.argv[1]).read().splitlines()
+print(''.join(lines[1:]).upper())
+PY
+)"
+
+# ---------------------------------------------------------------------------
+# synthetic VCF: proper ## header + #CHROM, 5 samples, mixed variant types.
+# REF bases are taken from the actual sequence so indel replacement matches.
+# ---------------------------------------------------------------------------
+VCF_PLAIN="$WORK/variants.vcf"
+python3 - "$VCF_PLAIN" "$REFSEQ" <<'PY'
+import sys
+out = sys.argv[1]
+ref = sys.argv[2]
+def b(pos1):  # 1-based ref base
+    return ref[pos1-1]
+
+lines = []
+lines.append("##fileformat=VCFv4.2")
+lines.append('##FILTER=<ID=PASS,Description="All filters passed">')
+lines.append('##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count">')
+lines.append('##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">')
+lines.append('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+samples = ["S1","S2","S3","S4","S5"]
+lines.append("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" + "\t".join(samples))
+
+def row(pos, rsid, r, a, info, gts, filt="PASS"):
+    return "\t".join([
+        "chrTest", str(pos), rsid, r, a, ".", filt, info, "GT", *gts])
+
+# 1) biallelic PASS SNP at pos 50
+p=50
+lines.append(row(p, "rs100", b(p), ("T" if b(p)!="T" else "A"),
+                 "AC=2;AF=0.25", ["0|1","0|0","1|1","0|0","1|0"]))
+
+# 2) multiallelic SNP at pos 90 (two alt alleles, both single-base)
+p=90
+alts=[x for x in "ACGT" if x!=b(p)][:2]
+lines.append(row(p, "rs200,rs201", b(p), ",".join(alts),
+                 "AC=1,1;AF=0.1,0.2", ["0|1","0|2","0|0","2|1","1|0"]))
+
+# 3) non-PASS variant at pos 120 (must be skipped)
+p=120
+lines.append(row(p, "rs300", b(p), ("G" if b(p)!="G" else "C"),
+                 "AC=1;AF=0.05", ["0|1","0|0","0|0","0|0","0|0"], filt="LowQual"))
+
+# 4) simple insertion at pos 150 (REF 1bp, ALT 2bp)
+p=150
+lines.append(row(p, "rs400", b(p), b(p)+"A",
+                 "AC=1;AF=0.3", ["0|1","0|0","1|0","0|0","0|0"]))
+
+# 5) simple deletion at pos 200 (REF 2bp, ALT 1bp)
+p=200
+r2=ref[p-1:p+1]
+lines.append(row(p, "rs500", r2, r2[0],
+                 "AC=1;AF=0.15", ["0|0","0|1","0|0","1|1","0|0"]))
+
+# 6) multiallelic indel at pos 250 (a SNP alt + an insertion alt)
+p=250
+snpalt=("T" if b(p)!="T" else "A")
+insalt=b(p)+"GG"
+lines.append(row(p, "rs600,rs601", b(p), snpalt+","+insalt,
+                 "AC=1,1;AF=0.12,0.22", ["0|1","0|2","1|2","0|0","2|0"]))
+
+open(out,"w").write("\n".join(lines)+"\n")
+PY
+
+VCF_GZ="$WORK/variants.vcf.gz"
+gzip -c "$VCF_PLAIN" > "$VCF_GZ"
+
+# ---------------------------------------------------------------------------
+# run reference (python) in its own dir
+# ---------------------------------------------------------------------------
+PYDIR="$WORK/py"
+CPPDIR="$WORK/cpp"
+mkdir -p "$PYDIR/SNPs_genome" "$CPPDIR/SNPs_genome"
+
+run_one() {
+    local dir="$1"; shift
+    ( cd "$dir" && "$@" "$VCF_GZ" "$CHR_FA" "resultTest" "yes" "$VCF_PLAIN" ) \
+        > "$dir/run.log" 2>&1
+    return $?
+}
+
+echo "Running enricher.py ..."
+run_one "$PYDIR" python3 "$ENRICHER_PY" || { echo "python run FAILED"; cat "$PYDIR/run.log"; exit 1; }
+echo "Running C++ enricher ..."
+run_one "$CPPDIR" "$ENRICHER_BIN" || { echo "C++ run FAILED"; cat "$CPPDIR/run.log"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# diff all four outputs
+# ---------------------------------------------------------------------------
+FAIL=0
+diff_out() {
+    local rel="$1"
+    if [ ! -e "$PYDIR/$rel" ] && [ ! -e "$CPPDIR/$rel" ]; then
+        echo "  SKIP (neither produced): $rel"
+        return
+    fi
+    if diff "$PYDIR/$rel" "$CPPDIR/$rel" > /dev/null 2>&1; then
+        echo "  OK   : $rel"
+    else
+        echo "  DIFF : $rel"
+        diff "$PYDIR/$rel" "$CPPDIR/$rel" | head -40
+        FAIL=1
+    fi
+}
+
+ENRICHED="SNPs_genome/resultTest_enriched/chrTest.enriched.fa"
+JSON="SNPs_genome/my_dict_chrTest.json"
+LOG="SNPs_genome/logchrTest.txt"
+FAKE="fake_variants.vcf_chrTest/fakechrTest.fa"
+
+echo "Comparing outputs:"
+diff_out "$ENRICHED"
+diff_out "$JSON"
+diff_out "$LOG"
+diff_out "$FAKE"
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+    echo "BYTE-IDENTICAL: PASS"
+    exit 0
+else
+    echo "BYTE-IDENTICAL: FAIL"
+    exit 1
+fi


### PR DESCRIPTION
## Motivation

Genome enrichment (`add-variants`) is the **#1 CRISPRme wall-clock cost**: a genome-wide 1000G run spent **~12.5 h (93% of wall-clock)** enriching chromosomes **one at a time, single-threaded**. `genomeEnrichment()` built `multiprocessing.Pool(th)` where `-th` **defaults to 1** and CRISPRme never passes it, so enrichment was serial. It also invoked `enricher.py` directly, so the compiled C++ `enricher` from #26 was not even on the hot path.

Stacks on **#26** (`cpp-enricher`).

## Changes

**1. Use the compiled `enricher` binary** (`genomeEnrichment_subprocess_VCF`)
Resolution order: `enricher` on `PATH` (`shutil.which`), then the compiled binary next to the reference impl, else `enricher.py` (Python reference) as a fallback. Same 5 positional args and order.

**2. Memory-bounded parallel default** (`genomeEnrichment`)
`add-variants` now parallelizes across chromosomes by default, bounded by a memory budget (each worker loads ~one chromosome, so unbounded fan-out can exhaust RAM). Workers = `max(1, min(base, mem_cap, n_chroms))` where `base` is `-th` if provided else `os.cpu_count()`, and `mem_cap = CRISPRME_MAX_MEM_GB // CRISPRME_ENRICH_WORKER_GB` (defaults **64** and **3**, mirroring the CRISPRme post-analysis `CRISPRME_MAX_MEM_GB` cap). A one-line stderr note reports the chosen worker count and budget. An explicit `fork` context is used (Linux default / the CRISPRme production platform), because `crispritz.py` dispatches commands at module scope with no `__main__` guard, so a `spawn` start method would re-import and re-invoke `add-variants` inside every worker.

**3. Race-safe directory creation** (`enricher.cpp`)
Concurrent workers now create the same shared `<dirGenome>_enriched` dir (and per-worker `fake_*` dirs). The TOCTOU `stat()`-then-`mkdir()` is replaced by an unconditional `mkdir(path, 0777)` that treats `errno == EEXIST` as success (only other failures error out). Adds `<cerrno>`.

## Test evidence

- **`verify_enricher.sh`: `BYTE-IDENTICAL: PASS`** — change #3 does not alter output vs. the Python reference.
- **Parallel correctness (synthetic 3-chromosome input):** `chr1/2/3` FASTAs + gzipped `ALL.chrN.*.vcf.gz` (proper `##`+`#CHROM` header, 5 samples, a mix of PASS SNP / multiallelic SNP / non-PASS / insertion / deletion). Ran `add-variants` twice:
  - serial: `CRISPRME_MAX_MEM_GB=1` -> **1 worker**
  - default: **3 workers** (capped to n_chroms; `os.cpu_count()=32`, `mem_cap=21`)
  
  Both runs produced the **same file set** and were **byte-identical across all 13 outputs** (enriched FASTAs, `my_dict_chrN.json`, `logchrN.txt`, `fake_*/fakechrN.fa`). **No mkdir race / no crash** in the parallel run. Compiled binary confirmed on the hot path via `PATH` (no fallback to `enricher.py`).

## Concurrency edge case found

Without an explicit start method, the parallel Pool re-imports `crispritz.py` on macOS (default `spawn`), and because the file has no `__main__` guard it re-runs `add-variants` recursively inside each worker (observed nested `variants_genome/variants_genome/`). Forcing the `fork` context — the Linux/CRISPRme default — avoids this and keeps macOS behavior identical to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)