### PR TITLE
Bump version to 2.8.0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.7.1" %}
+{% set version = "2.8.0" %}
 
 package:
   name: crispritz

--- a/crispritz.py
+++ b/crispritz.py
@@ -18,7 +18,7 @@ origin_path = os.path.dirname(os.path.realpath(__file__))
 # conda path
 conda_path = "opt/crispritz/"
 
-VERSION = "2.7.1"
+VERSION = "2.8.0"
 
 if "--debug" in sys.argv[1:]:
     # for quick local tests


### PR DESCRIPTION
Version bump for the CRISPRitz **2.8.0** release line (target: `2.8.0-dev`).

`crispritz.py` `VERSION` and `conda/meta.yaml` version 2.7.1 → **2.8.0**.

2.8.0 integrates (all green on `2.8.0-dev`):
- **Python 3.11** modernization + azimuth on-target scoring restored + fixed docker workflow (#24)
- **Byte-identical C++ enricher** replacing the single-threaded Python `enricher.py` (#26)
- **Memory-bounded cross-chromosome parallelism** for `add-variants` (#27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)