### PR TITLE
azimuth: lazy/optional matplotlib import (scoring no longer needs it)

### DIFF
--- a/sourceCode/Python_Scripts/Scores/azimuth/load_data.py
+++ b/sourceCode/Python_Scripts/Scores/azimuth/load_data.py
@@ -1,6 +1,9 @@
 import pandas
 from . import util
-import matplotlib.pyplot as plt
+try:  # only used by plotting helpers, not by scoring
+    import matplotlib.pyplot as plt
+except Exception:
+    plt = None
 import scipy as sp
 import scipy.stats
 import numpy as np

--- a/sourceCode/Python_Scripts/Scores/azimuth/models/GP.py
+++ b/sourceCode/Python_Scripts/Scores/azimuth/models/GP.py
@@ -1,5 +1,8 @@
 import numpy as np
-import matplotlib.pyplot as plt
+try:  # only used by training/plotting helpers, not by inference/scoring
+    import matplotlib.pyplot as plt
+except Exception:
+    plt = None
 
 
 def gp_on_fold(feature_sets, train, test, y, y_all, inputs, dim, dimsum, learn_options):

--- a/sourceCode/Python_Scripts/Scores/azimuth/util.py
+++ b/sourceCode/Python_Scripts/Scores/azimuth/util.py
@@ -1,6 +1,10 @@
 import pandas
-import matplotlib.pylab as plt
-import pylab as pl # so can just grab qqplotting code from fastlmm directly
+try:  # matplotlib is only used by plotting/analysis helpers below, never by scoring
+    import matplotlib.pylab as plt
+    import pylab as pl  # so can just grab qqplotting code from fastlmm directly
+except Exception:  # keep azimuth importable (and on-target scoring working) w/o matplotlib
+    plt = None
+    pl = None
 import scipy.stats
 import scipy as sp
 import numpy as np


### PR DESCRIPTION
The vendored azimuth pulled **matplotlib in transitively** via module-level \`import matplotlib.pyplot/pylab\` in \`util.py\`, \`models/GP.py\`, and \`load_data.py\` — even though matplotlib is only used by plotting/analysis helpers, **never by on-target scoring**. That made scoring fragile w.r.t. matplotlib versions (the import chain broke under the pinned numpy 1.24.4 until matplotlib was downgraded during validation).

**Fix:** wrap those imports in \`try/except\` (\`plt/pl = None\` on failure). `plt`/`pl` are only referenced inside plotting functions, so scoring is unaffected.

**Verified on ml007** (Python 3.11 + sklearn 1.1.3 + numpy 1.24.4), with matplotlib **blocked/unavailable**:
```
matplotlib: BLOCKED as intended
azimuth imported OK ; model UNPICKLED OK
SCORES: [0.68, 0.73] -> [68, 73]   (identical to the with-matplotlib run)
```

matplotlib remains a dependency for CRISPRitz’s own `Plot/` report scripts, but the on-target scoring path is now matplotlib-independent and robust. Leaner than pinning matplotlib just to satisfy a transitive import that scoring never uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)