### PR TITLE
recipe: add zlib dependency for the C++ enricher build

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,8 @@ requirements:
     - make
     - boost
     - openmp
-    
+    - zlib
+
   host:
     - intervaltree
     - matplotlib
@@ -39,6 +40,7 @@ requirements:
     - tk
     - openmp
     - libdeflate
+    - zlib
     - python >=3.11
 
   run:
@@ -61,6 +63,7 @@ requirements:
     - tk
     - openmp
     - libdeflate
+    - zlib
     - python >=3.11
 
 test:


### PR DESCRIPTION
The 2.8.0 C++ `enricher` (`sourceCode/Python_Scripts/Enrichment/enricher.cpp`) uses **zlib** — `#include <zlib.h>`, linked with `-lz`. It was only present transitively, so a from-source build in a bare env failed with `zlib.h: No such file or directory` (hit during the ml007 validation).

Declare **`zlib`** explicitly in `build`, `host`, and `run` so source builds are reproducible. (The existing `libdeflate` is a different library and does not provide `zlib.h`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)