### PR TITLE
CI: publish multi-arch Docker image on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,23 +1,46 @@
-name: Docker multi-arch build
+name: Docker multi-arch build & publish
 
-# Builds — but does NOT push — the root Dockerfile for both linux/amd64 and
-# linux/arm64 (Apple Silicon / aarch64).
+# Builds the root Dockerfile for both linux/amd64 and linux/arm64 (Apple
+# Silicon / aarch64). The Dockerfile builds CRISPRitz FROM SOURCE on
+# Python 3.11 (it previously failed on BOTH arches at `conda install
+# python=3.8`, an unsatisfiable solve against the current base image). It
+# compiles the C++ binaries and pins the scoring stack to scikit-learn 1.1.3 +
+# numpy 1.24.4 so the vendored azimuth model loads.
 #
-# The Dockerfile was fixed to build on Python 3.11 (it previously failed on
-# BOTH arches at `conda install python=3.8`, an unsatisfiable solve against the
-# current continuumio/miniconda3 base). It now compiles the C++ binaries from
-# source and pins the scoring stack to scikit-learn 1.1.* + numpy<2 so the
-# vendored azimuth model loads. This job now gates the PR on both arches
-# building successfully.
+#   - pull_request / branch push : BUILD both arches, do NOT push (gates the PR).
+#   - version tag (v* / *.*.*)   : BUILD both arches and PUSH to Docker Hub.
+#   - manual (workflow_dispatch) : PUSH only when run with publish=true; tags the
+#                                  image with the `image_tag` input + :latest.
+#                                  Use this to (re)publish an existing release
+#                                  without moving the git tag.
+#
+# Publishing pushes pinellolab/crispritz:latest + :<tag> using the repository
+# secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (a write-scoped access token).
 
 on:
-  push:
   pull_request:
+  push:
+    tags:
+      - "v*"
+      - "*.*.*"
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Push the image to Docker Hub"
+        type: boolean
+        default: false
+      image_tag:
+        description: "Image tag to publish (e.g. v2.8.0); also updates :latest"
+        type: string
+        default: ""
 
 jobs:
-  buildx:
+  # ---------------------------------------------------------------------------
+  # Validation build: build both arches, do NOT push. Runs on PRs & branch push.
+  # ---------------------------------------------------------------------------
+  build:
     name: buildx amd64 + arm64 (no push)
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,3 +58,57 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false
+          tags: crispritz:ci-multiarch
+
+  # ---------------------------------------------------------------------------
+  # Publish build: build both arches and push to Docker Hub.
+  #   - automatically on version tags
+  #   - manually via workflow_dispatch with publish=true
+  # ---------------------------------------------------------------------------
+  publish:
+    name: Publish multi-arch image
+    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve image tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            REF="${{ inputs.image_tag }}"
+          else
+            REF="${{ github.ref_name }}"
+          fi
+          if [ -z "$REF" ]; then
+            echo "No image tag provided (workflow_dispatch requires image_tag)." >&2
+            exit 1
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Publishing pinellolab/crispritz:$REF + :latest"
+
+      - name: Checkout ${{ steps.meta.outputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            pinellolab/crispritz:latest
+            pinellolab/crispritz:${{ steps.meta.outputs.ref }}


### PR DESCRIPTION
Adds a **publish** job to `docker.yml` so the standalone (build-from-source) image ships to Docker Hub as `pinellolab/crispritz:latest` + `:<tag>`, mirroring CRISPRme's `docker-multiarch.yml`.

- **PR / branch push** → build both arches, no push (gates the PR, unchanged).
- **version tag** (`v*` / `*.*.*`) → build + push `linux/amd64,linux/arm64`.
- **workflow_dispatch** with `publish=true` + `image_tag` → (re)publish an existing release without moving the git tag — used to publish **v2.8.0**, whose tag predates this workflow.

Requires repo secrets **DOCKERHUB_USERNAME** and **DOCKERHUB_TOKEN** (write-scoped), same as CRISPRme.