### PR TITLE
conda/meta.yaml: fix stale InfOmics URLs -> pinellolab

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/InfOmics/CRISPRitz/archive/v{{ version }}.tar.gz
+  url: https://github.com/pinellolab/CRISPRitz/archive/v{{ version }}.tar.gz
   sha256: 
 
 build:
@@ -71,6 +71,6 @@ test:
     - crispritz.py
 
 about:
-  home: https://github.com/InfOmics/CRISPRitz
+  home: https://github.com/pinellolab/CRISPRitz
   license: GPL3
   summary: CRISPRitz, tool package for CRISPR experiments assessment and analysis.


### PR DESCRIPTION
The in-tree `conda/meta.yaml` stub still pointed `source.url` and `about.home` at **InfOmics/CRISPRitz**, but the active fork, all releases, and the live Bioconda recipe are on **pinellolab/CRISPRitz**. Cosmetic (Bioconda uses its own recipe, not this file), but removes the self-contradiction.