### PR TITLE
fix: add-variants diagnostic to stdout (unblocks CRISPRme enrichment)

### DIFF
--- a/crispritz.py
+++ b/crispritz.py
@@ -718,7 +718,7 @@ def genomeEnrichment():
             os.environ.get("CRISPRME_MAX_MEM_GB", "64"),
             os.environ.get("CRISPRME_ENRICH_WORKER_GB", "3"),
         ),
-        file=sys.stderr,
+        file=sys.stdout,
     )
     # Use a 'fork' context: crispritz.py runs its command dispatch at module
     # scope (no __main__ guard), so a 'spawn' start method would re-import and


### PR DESCRIPTION
## Problem
CRISPRme decides each pipeline stage's success by whether the redirected **stderr** log is non-empty (`if [ -s $logerror ]; then ... exit 1` in `submit_job_automated_new_multiple_vcfs.sh`). crispritz 2.8.0's `add-variants` prints its worker-count diagnostic — `add-variants: enriching N chromosome(s) with M worker(s) (mem budget ...)` — to **stderr** (`crispritz.py` ~line 721). That single line makes CRISPRme's enrichment check fire and abort every run with a false **"Genome enrichment failed"**, even though `add-variants` returns rc=0.

## Impact
Breaks **CRISPRme 2.2.0** (which pins crispritz 2.8.0) at the genome-enrichment step. Same failure class as the CRISPRme 2.1.13 post-analysis stderr fix.

## Fix
Route the informational message to **stdout**. (It's the only `file=sys.stderr` in the file.)

## Verification
On ml007, a from-scratch py3.11 CRISPRme 2.2.0 `complete-test` (chr22/1000G) that previously failed **deterministically** at enrichment now gets past it with this patch applied.

Suggest cutting this as **crispritz 2.8.1**. Longer term, CRISPRme's `[ -s $logerror ]` success checks should key on exit codes rather than stderr-emptiness.