### PR TITLE
fix: normalize multi-rsID ';' in add-variants (root cause of CRISPRme #143)

### DIFF
--- a/sourceCode/Python_Scripts/Enrichment/enricher.cpp
+++ b/sourceCode/Python_Scripts/Enrichment/enricher.cpp
@@ -575,6 +575,13 @@ int main(int argc, char **argv) {
     std::string raw;
     while (vcf.getRawLine(raw)) {
         std::vector<std::string> line = splitStr(pyStrip(raw), '\t');
+        // issue #143: the per-position variant-info string is ';'-delimited
+        // (samples;ref,alt;rsID;AF). The VCF ID column (line[2]) can contain ';'
+        // for dbSNP multi-rsID records ("rs1;rs2"), colliding with that delimiter
+        // and shifting AF (and every field after) by one -> downstream float(rsID)
+        // crash. Normalize the ID field's ';' to ',' so rsID stays one field.
+        if (line.size() > 2)
+            std::replace(line[2].begin(), line[2].end(), ';', ',');
         if (first_line) {
             first_line = false;
             std::vector<std::string> splitted = splitStr(line[7], ';');

--- a/sourceCode/Python_Scripts/Enrichment/enricher.py
+++ b/sourceCode/Python_Scripts/Enrichment/enricher.py
@@ -353,6 +353,14 @@ for line in inAltFile:
         break
 for line in inAltFile:
     line = line.strip().split('\t')
+    # issue #143: the variant-info string embedded per position is ';'-delimited
+    # (samples;ref,alt;rsID;AF). The VCF ID column (line[2]) can itself contain
+    # ';' for dbSNP multi-rsID records (e.g. "rs1;rs2"), which collides with that
+    # delimiter and shifts AF (and every field after) by one -> downstream
+    # float(rsID) crashes. Normalize the ID field's ';' to ',' (CRISPRme's
+    # multi-value convention) once, so all rsID uses below stay a single field.
+    if len(line) > 2:
+        line[2] = line[2].replace(";", ",")
     if first_line:
         first_line = False
         splitted = line[7].split(";")


### PR DESCRIPTION
## Root cause of CRISPRme #143 (data-destroying crash)

The variant-info string `add-variants` embeds per position is **`;`-delimited** — `samples;ref,alt;rsID;AF` (`enricher.py` ~230/232, `enricher.cpp` ~253/301). But the VCF **ID column** (`line[2]`) can itself contain `;`: dbSNP encodes **multi-rsID** records as `rs1;rs2`. That `;` collides with the field delimiter, injects an extra field, and shifts `AF` (and everything after) by one.

Downstream in CRISPRme, `resultIntegrator.py` then calls `float()` on what it thinks is the MAF column but is actually an rsID → the run dies in the final "Integrating results" step, **after** hours of successful work, and the cleanup deletes the completed output (pinellolab/CRISPRme#143).

## Fix
Normalize the ID field's `;` → `,` (CRISPRme's multi-value convention) **once**, right where each VCF record is split — in both the Python and C++ enrichers. `rsID` then stays a single field and every column downstream aligns.

## Reproduced + verified
Synthetic reproducer: a single-sample personal VCF with a **multi-rsID `rs1;rs2` SNV duplicated at one CHR+POS** (as `bcftools norm -m-` produces from a multiallelic split), placed inside an exact-match guide target, run through CRISPRme `complete-search`:

| | rsID col | AF col | result |
|---|---|---|---|
| **before** | `rs1` | `rs2` | `float('rs2')` → crash, results deleted |
| **after** | `rs1,rs2` | `0.3` | aligned, run completes ✅ |

Companion CRISPRme PR (defensive layer: skip malformed rows + stop deleting results on late-stage failure): pinellolab/CRISPRme#144.

Suggest folding into the next crispritz release.
